### PR TITLE
K8s

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -87,7 +87,7 @@
   
       # Configure keymap in X11
       layout = "us";
-      xkbOptions = "eurosign:e";
+      xkb.options = "eurosign:e";
       # Enable touchpad support (enabled default in most desktopManager).
       # libinput.enable = true;
     };
@@ -103,10 +103,19 @@
     openssh = {
       enable = true;
     };
+    kubernetes = {
+      easyCerts = true;
+      roles = [
+        "master"
+        "node"
+      ];
+      masterAddress = "127.0.0.1";
+      pki.enable = true;
+    };
   };
 
 
-  virtualisation.docker.enable = true;
+  # virtualisation.docker.enable = true;
 
   # sound.enable = true;
   # hardware.pulseaudio.enable = true;
@@ -126,7 +135,7 @@
     neovim
     wget
     jq
-    docker-compose # why do I need this here?
+    # docker-compose # why do I need this here?
     # direnv
     # nix-direnv
   ];

--- a/configuration.nix
+++ b/configuration.nix
@@ -75,9 +75,9 @@
   #   keyMap = "us";
   # };
 
-  # Enable the X11 windowing system.
   services = { 
     xserver = { 
+      # Enable the X11 windowing system.
       enable = true;
       videoDrivers = [ "nvidia" ];
 
@@ -104,7 +104,6 @@
       enable = true;
     };
     kubernetes = {
-      easyCerts = true;
       roles = [
         "master"
         "node"


### PR DESCRIPTION
I'm trying to enable Kubernetes on my NixOS system via `configuration.nix`, but core services (notably `certmgr` and `kube-addon-manager`) fail to start, resulting in a non-functional Kubernetes installation.
Certificate management is [a known pain](https://youtu.be/leR6m2plirs?t=513)


- cfssl service runs, but TLS handshake fails (curl to https://127.0.0.1:8888 reports "unknown CA").
- System PKI files (in `/var/lib/cfssl/`) are present and owned by `cfssl`.

```
sudo ls /var/lib/cfssl/ -l
[sudo] password for alex: 
total 28
-r-------- 1 cfssl cfssl   33 Oct 11 10:46 apitoken.secret

  ```
- symlink is present in the secrets 
```
✔ ~/workshop/nix-things [k8s L|✔]                                                                         
08:08 $ ls /var/lib/kubernetes/secrets/ -l                                                                
total 124                                                                                                 
lrwxrwxrwx 1 root       root         30 Oct 22 08:09 apitoken.secret -> /var/lib/cfssl/apitoken.secret
```
- certmgr logs errors
```
# journalctl -u certmgr
Oct 03 10:32:41 nixos certmgr-pre-start[19987]: time="2025-10-03T10:32:41+07:00" level=error msg="managed: failed loading spec from /nix/store/s4hj2yiim0dddyb7yfx8m2hizw6h2rm9-certmgr.d/addonManager.json: failed reading /nix/store/s4hj2yiim0dddyb7yfx8m2hizw6h2rm9-certmgr.d/addonManager.json: failed reading auth_key_file /var/lib/kubernetes/secrets/apitoken.secret: open /var/lib/kubernetes/secrets/apitoken.secret: no such file or directory"
Oct 03 10:32:41 nixos certmgr-pre-start[19987]: time="2025-10-03T10:32:41+07:00" level=error msg="stopping directory scan due to failed reading /nix/store/s4hj2yiim0dddyb7yfx8m2hizw6h2rm9-certmgr.d/addonManager.json: failed reading auth_key_file /var/lib/kubernetes/secrets/apitoken.secret: open /var/lib/kubernetes/secrets/apitoken.secret: no such file or directory"
Oct 03 10:32:41 nixos certmgr-pre-start[19987]: time="2025-10-03T10:32:41+07:00" level=error msg="Failed: failed reading /nix/store/s4hj2yiim0dddyb7yfx8m2hizw6h2rm9-certmgr.d/addonManager.json: failed reading auth_key_file /var/lib/kubernetes/secrets/apitoken.secret: open /var/lib/kubernetes/secrets/apitoken.secret: no such file or directory"

```

**References**

https://wiki.nixos.org/wiki/Kubernetes
https://nixos.org/manual/nixos/stable/#sec-kubernetes
https://nixos.org/manual/nixos/stable/options#opt-services.kubernetes.addonManager.enable